### PR TITLE
Port to Folia 1.21 and update plugin version to 1.1.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>me.honeyberries</groupId>
     <artifactId>ExplodingPlayers</artifactId>
-    <version>1.0.2</version>
+    <version>1.1.0</version>
     <packaging>jar</packaging>
 
     <name>ExplodingPlayers</name>
@@ -66,7 +66,7 @@
         <dependency>
             <groupId>io.papermc.paper</groupId>
             <artifactId>paper-api</artifactId>
-            <version>1.19-R0.1-SNAPSHOT</version>
+            <version>1.21-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/src/main/java/me/honeyberries/explodingPlayers/EntityListener.java
+++ b/src/main/java/me/honeyberries/explodingPlayers/EntityListener.java
@@ -24,7 +24,13 @@ public class EntityListener implements Listener {
             if (ExplodingPlayersSettings.getInstance().getListOfExplodingPlayers().contains(hostage.getUniqueId().toString())) {
                 if (player.hasPermission("explodingPlayers.explode.use")) {
                     //torture the hostage
-                    hostage.getWorld().createExplosion(hostage.getLocation(), ExplodingPlayersSettings.getInstance().getExplosionPower());
+                    ExplodingPlayers plugin = ExplodingPlayers.getInstance();
+                    hostage.getScheduler().execute(plugin, () -> {
+                        // We are now on the entity's region thread, get current location again if needed,
+                        // or use the location captured when the event fired if that's more appropriate.
+                        // For an immediate explosion, the captured event location for the explosion itself is fine.
+                        hostage.getWorld().createExplosion(hostage.getLocation(), ExplodingPlayersSettings.getInstance().getExplosionPower());
+                    }, null, 0L);
                 }
 
                 else {

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,7 +1,8 @@
 name: ExplodingPlayers
-version: '1.0.2'
+version: '1.1.0'
 main: me.honeyberries.explodingPlayers.ExplodingPlayers
-api-version: '1.19'
+api-version: '1.21'
+folia-supported: true
 authors: [ HoneyBerries ]
 
 commands:


### PR DESCRIPTION
Key changes:
- Updated pom.xml to use paper-api for 1.21.
- Updated plugin.yml for api-version 1.21 and added folia-supported: true.
- Updated plugin version to 1.1.0 in pom.xml and plugin.yml.
- Modified EntityListener.java to use Entity#getScheduler() for thread-safe explosion creation on Folia.